### PR TITLE
Fixed score calculation: now correctly rounds to 100*n

### DIFF
--- a/game/game.script
+++ b/game/game.script
@@ -40,7 +40,7 @@ local function drop_box(self, id)
 		go.animate("#", "zoom_factor", go.PLAYBACK_ONCE_FORWARD, zoom_to, go.EASING_LINEAR, 1, 0, function()
 			msg.post(msg.url(nil, BOX, "sprite"), "enable")
 			msg.post(".", "acquire_input_focus")
-			msg.post("#hud", "update_score", { score = math.ceil(height * 100) })
+			msg.post("#hud", "update_score", { score = math.floor(max_height(self) + 0.5) * 100 })
 		end)
 	end)
 end

--- a/game/game.script
+++ b/game/game.script
@@ -35,12 +35,18 @@ local function drop_box(self, id)
 
 	-- wait 2 seconds, then zoom, show moving box and update score
 	wait(2, function()
-		local height = max_height(self)
-		local zoom_to = 1 - height * 0.05
+		local zoom_to = 1 - max_height(self) * 0.05
 		go.animate("#", "zoom_factor", go.PLAYBACK_ONCE_FORWARD, zoom_to, go.EASING_LINEAR, 1, 0, function()
 			msg.post(msg.url(nil, BOX, "sprite"), "enable")
 			msg.post(".", "acquire_input_focus")
-			msg.post("#hud", "update_score", { score = math.floor(max_height(self) + 0.5) * 100 })
+			msg.post("#hud", "update_score", {
+				-- the score is equal to the number of boxes multiplied by 100;
+				-- but max_height() returns the approximate height of the tower;
+				-- we round this height by adding 0.5 and flooring the result (since Lua doesn't have a built-in 'round' function)
+				score = math.floor(
+					max_height(self) + 0.5 -- we call max_height again here, because the number of boxes could have changed during the animation (boxes may still be falling)
+				) * 100
+			})
 		end)
 	end)
 end


### PR DESCRIPTION
The score was close to number of boxes * 100, but not exactly (please see _before.png_ attached). Now it's always equal to number of boxes * 100 (please see _after.png_ attached).

Also, I call the height calculation (_max_height_ function) after the animation, as the number of boxes may be changing during the animation (if boxes are still falling).

<img src="https://github.com/britzl/towerz/assets/11616311/6dd02e9d-a81e-4b3d-ac7d-226804d7a792" alt="before" height="700"/> <img src="https://github.com/britzl/towerz/assets/11616311/ea8f95d0-7a0c-4b41-91d2-da7ce8b96439" alt="after" height="700"/>